### PR TITLE
update : auto_unregister, sync(for DoubleChest)

### DIFF
--- a/src/main/java/com/github/aruka/cyclotron/Cyclotron.java
+++ b/src/main/java/com/github/aruka/cyclotron/Cyclotron.java
@@ -2,6 +2,7 @@ package com.github.aruka.cyclotron;
 
 import com.github.aruka.cyclotron.command.Filter;
 
+import com.github.aruka.cyclotron.listener.ContainerBreak;
 import com.github.aruka.cyclotron.listener.ContainerClick;
 import com.github.aruka.cyclotron.listener.HopperTransfer;
 import org.bukkit.Bukkit;
@@ -60,6 +61,7 @@ public final class Cyclotron extends JavaPlugin {
         getCommand("filter").setTabCompleter(new Filter());
         getServer().getPluginManager().registerEvents(new ContainerClick(), this);
         getServer().getPluginManager().registerEvents(new HopperTransfer(), this);
+        getServer().getPluginManager().registerEvents(new ContainerBreak(), this);
         getAllCraftingNamespace();
     }
 

--- a/src/main/java/com/github/aruka/cyclotron/listener/ContainerBreak.java
+++ b/src/main/java/com/github/aruka/cyclotron/listener/ContainerBreak.java
@@ -1,0 +1,18 @@
+package com.github.aruka.cyclotron.listener;
+
+import com.github.aruka.cyclotron.Cyclotron;
+import com.github.aruka.cyclotron.util.Util;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+public class ContainerBreak implements Listener {
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Block block = event.getBlock();
+        if (!Cyclotron.CARGO_CONTAINER.contains(block.getType())) return;
+        if (!block.hasMetadata(Cyclotron.CyclotronKey)) return;
+        Util.blockDataClear(block);
+    }
+}

--- a/src/main/java/com/github/aruka/cyclotron/listener/ContainerClick.java
+++ b/src/main/java/com/github/aruka/cyclotron/listener/ContainerClick.java
@@ -26,7 +26,7 @@ public class ContainerClick implements Listener {
         if (
                 block == null ||
                 block.getType().equals(Material.AIR) ||
-                !event.getAction().equals(Action.LEFT_CLICK_BLOCK) ||
+                !event.getAction().equals(Action.RIGHT_CLICK_BLOCK) ||
                 !Cyclotron.CARGO_CONTAINER.contains(block.getType()) ||
                 (!Filter.FILTER_QUERIES.containsKey(player.getUniqueId()) && !Filter.FILTER_QUERY_KIND.containsKey(player.getUniqueId()))
         ) {
@@ -42,7 +42,7 @@ public class ContainerClick implements Listener {
             case "unregister" -> unregister(block, player);
             case "info" -> info(block, player);
             case "clear" -> {
-                if (player.hasPermission("cyclotron.clear")) clear(block);
+                if (player.hasPermission("cyclotron.clear")) Util.blockDataClear(block);
             }
         }
         removeFlags(player.getUniqueId());
@@ -53,6 +53,8 @@ public class ContainerClick implements Listener {
         Filter.FILTER_QUERY_KIND.remove(uuid);
         Filter.FILTER_QUERIES.remove(uuid);
     }
+
+
 
     private void register(Block container, Player player) {
         String query = Filter.FILTER_QUERIES.get(player.getUniqueId());
@@ -75,6 +77,7 @@ public class ContainerClick implements Listener {
         newData[hold.length] = query;
 
         Util.replaceMetadata(container, new FixedMetadataValue(Cyclotron.INSTANCE, Util.convertFlat(newData)));
+        Util.doubleChest(container);
         player.sendMessage(String.format("Successful to register '%s'.", query));
     }
 
@@ -91,7 +94,8 @@ public class ContainerClick implements Listener {
             return;
         } else if (data.length == 1) {
             // oldData.contains(query) -> true, length = 1
-            clear(container);
+            Util.blockDataClear(container);
+            Util.doubleChest(container);
             player.sendMessage(String.format("Successful to unregister '%s'.", query));
             player.sendMessage("Now recipes='[]'.");
             return;
@@ -104,7 +108,7 @@ public class ContainerClick implements Listener {
             index++;
         }
         Util.replaceMetadata(container, new FixedMetadataValue(Cyclotron.INSTANCE, Util.convertFlat(newData)));
-
+        Util.doubleChest(container);
         player.sendMessage(String.format("Successful to unregister '%s'.", query));
         player.sendMessage("Now recipes=" + Arrays.toString(newData));
     }

--- a/src/main/java/com/github/aruka/cyclotron/listener/HopperTransfer.java
+++ b/src/main/java/com/github/aruka/cyclotron/listener/HopperTransfer.java
@@ -76,6 +76,7 @@ public class HopperTransfer implements Listener {
 
         int nextIndex = (startIndex + 1) % recipes.length;
         Util.replaceMetadataSpecifiedKey(block, Cyclotron.CyclotronIndexKey, new FixedMetadataValue(Cyclotron.INSTANCE, nextIndex));
+        Util.doubleChest(block);
     }
 
     private void make(Recipe recipe, Inventory inventory) {

--- a/src/main/java/com/github/aruka/cyclotron/util/Util.java
+++ b/src/main/java/com/github/aruka/cyclotron/util/Util.java
@@ -1,14 +1,20 @@
 package com.github.aruka.cyclotron.util;
 
 import com.github.aruka.cyclotron.Cyclotron;
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.Container;
+import org.bukkit.block.DoubleChest;
+import org.bukkit.inventory.DoubleChestInventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class Util {
@@ -53,5 +59,51 @@ public class Util {
     public static void replaceMetadataSpecifiedKey(Block block, String key, MetadataValue value) {
         if (block.hasMetadata(key)) block.removeMetadata(key, Cyclotron.INSTANCE);
         block.setMetadata(key, value);
+    }
+
+    public static void blockDataClear(Block block) {
+        block.removeMetadata(Cyclotron.CyclotronKey, Cyclotron.INSTANCE);
+        block.removeMetadata(Cyclotron.CyclotronIndexKey, Cyclotron.INSTANCE);
+    }
+
+    public static void doubleChest(Block block) {
+        if (((Container) block.getState()).getInventory() instanceof DoubleChestInventory doubleInventory) {
+            DoubleChest chest = doubleInventory.getHolder();
+            Block[] blocks = getDoubleChest(chest.getLocation());
+            int sourceIndex = Arrays.stream(blocks).map(Block::getLocation).toList().indexOf(block.getLocation());
+            int clientIndex = sourceIndex == 0 ? 1 : 0;
+            sync(blocks[sourceIndex], blocks[clientIndex]);
+        }
+    }
+
+    private static void sync(Block source, Block client) {
+        if (!source.hasMetadata(Cyclotron.CyclotronKey) && !client.hasMetadata(Cyclotron.CyclotronKey)) {
+            return;
+        } else if (!source.hasMetadata(Cyclotron.CyclotronKey)) {
+            // clear
+            Util.blockDataClear(client);
+            return;
+        }
+
+        MetadataValue value = source.getMetadata(Cyclotron.CyclotronKey).get(0);
+        client.setMetadata(Cyclotron.CyclotronKey, value);
+
+        if (source.hasMetadata(Cyclotron.CyclotronIndexKey)) {
+            MetadataValue index = source.getMetadata(Cyclotron.CyclotronIndexKey).get(0);
+            client.setMetadata(Cyclotron.CyclotronIndexKey, index);
+        }
+
+    }
+
+    private static Block[] getDoubleChest(Location location) {
+        World world = location.getWorld();
+        double x1 = Math.floor(location.getX());
+        double x2 = Math.ceil(location.getX());
+        double y = location.getY();
+        double z1 = Math.floor(location.getZ());
+        double z2 = Math.ceil(location.getZ());
+        Location loc1 = new Location(world, x1, y, z1);
+        Location loc2 = new Location(world, x2, y, z2);
+        return new Block[]{world.getBlockAt(loc1), world.getBlockAt(loc2)};
     }
 }


### PR DESCRIPTION
add
- `auto_unregister` : unregister all recipes when Cargo are broken.
- `sync` : sync data between double chest right side and left side.